### PR TITLE
remove_regex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,6 +372,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -759,7 +770,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
  "libc",
  "rand_chacha",
  "rand_core",
@@ -782,7 +793,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -830,6 +841,7 @@ dependencies = [
  "serenity",
  "tokio",
  "toml",
+ "uuid",
 ]
 
 [[package]]
@@ -1379,6 +1391,16 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "uuid"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1674845326ee10d37ca60470760d4288a6f80f304007d92e5c53bab78c9cfd79"
+dependencies = [
+ "getrandom 0.2.8",
+ "serde",
+]
 
 [[package]]
 name = "uwl"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ regex = "1.7.3"
 serde = { version = "1.0.158", features = ["derive"] }
 toml = "0.7.3"
 base64 = "0.21.0"
+uuid = { version = "1.3.0", features = ["v4", "serde"] }

--- a/src/commands/staff.rs
+++ b/src/commands/staff.rs
@@ -4,6 +4,7 @@ use serenity::{
     model::{channel::Message, prelude::UserId},
     prelude::*,
 };
+use uuid::Uuid;
 
 #[command]
 async fn staff(ctx: &Context, msg: &Message) -> CommandResult {
@@ -29,6 +30,7 @@ async fn staff(ctx: &Context, msg: &Message) -> CommandResult {
                 "The staff commands are:\n\
                             `staff help` - Shows this message\n\
                             `staff add_regex` - Add a new regex phrase to the list\n\
+                            `staff remove_regex` - Remove a regex phrase from the list\n\
                             `staff list_regex` - Lists all the current blocked regex phrases\n\
                             `staff grab_pfp` - Grabs a specified user's pfp\n\
                             `staff grab_timestamp` - Find out when a specified user's account was made \n\
@@ -61,6 +63,25 @@ async fn staff(ctx: &Context, msg: &Message) -> CommandResult {
             let status_message = format!(
                 "Added the regex phrase:\n||```{}```||",
                 new_block_phrase_clone
+            );
+            msg.reply(ctx, status_message).await?;
+            return Ok(());
+        }
+        "remove_regex" => {
+            let id = args.next().unwrap_or("none");
+            if id == "none" {
+                msg.reply(
+                    ctx,
+                    "You need to specify a UUID you silly kitten :heart:",
+                )
+                .await?;
+                return Ok(());
+            }
+            let id = id.parse::<Uuid>().unwrap();
+            toml::remove_block_phrase(id);
+            let status_message = format!(
+                "Removed the regex phrase with UUID: {}",
+                id
             );
             msg.reply(ctx, status_message).await?;
             return Ok(());

--- a/src/commands/staff.rs
+++ b/src/commands/staff.rs
@@ -68,12 +68,17 @@ async fn staff(ctx: &Context, msg: &Message) -> CommandResult {
         "list_regex" => {
             let blocked_phrases = toml::list_block_phrases();
             let mut formatted_blocked_phrases = String::new();
-            for phrase in blocked_phrases {
+            for (id, phrase) in blocked_phrases {
+                formatted_blocked_phrases.push_str(&id.to_string());
+                formatted_blocked_phrases.push_str(&" | ");
                 formatted_blocked_phrases.push_str(&phrase);
                 formatted_blocked_phrases.push('\n');
             }
 
-            let status_message = format!("The current regex being used are **[WARNING CONTAINS SENSITIVE MESSAGES]**\n||```{}```||", formatted_blocked_phrases);
+            let status_message = format!("The current regex being used are **[WARNING CONTAINS SENSITIVE MESSAGES]**\n\
+            ||```                  ID                 | REGEX\n\
+            {}\
+            ```||", formatted_blocked_phrases);
             msg.reply(ctx, status_message).await?;
             return Ok(());
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,7 +68,7 @@ impl EventHandler for Handler {
 
                     let mut embed = CreateEmbed::default();
                     embed.title("Message blocked due to matching a set regex pattern");
-                    embed.description(format!("<@{}> sent a message that matched a regex pattern", msg.author.id));
+                    embed.description(format!("<@{}> sent a message that matched regex pattern \"{}\"", msg.author.id, id));
                     embed.color(0xFFA500);
                     embed.field("Their message is the following below:", format!("||{}||", msg.content), false);
                     embed.footer(|f| f.text("React with 🚫 to dismiss this and log to console"));

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,7 @@ impl EventHandler for Handler {
 
             let list_block_phrases = toml::list_block_phrases();
 
-            for phrase in list_block_phrases {
+            for (id, phrase) in list_block_phrases {
                 let re = Regex::new(&phrase).unwrap();
                 if re.is_match(&msg.content) {
                     if let Err(why) = msg.delete(&ctx.http).await {
@@ -84,7 +84,7 @@ impl EventHandler for Handler {
                     tokio::spawn(async move {
                         tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
                         if let Err(why) = msg.channel_id.delete_message(&ctx_clone.http, reply_msg).await {
-                            println!("Error deleting message: {:?}", why);
+                            eprintln!("Error deleting message: {:?}", why);
                         }
                     });
                     return;

--- a/src/managers/toml.rs
+++ b/src/managers/toml.rs
@@ -1,3 +1,6 @@
+use std::{collections::HashMap, hash::Hash};
+
+use uuid::Uuid;
 use base64::{Engine as _, engine::general_purpose};
 use serde::{Serialize, Deserialize};
 
@@ -6,15 +9,19 @@ pub struct Config {
     pub token: String,
     pub staff: Vec<String>,
     pub log_channel: u64,
-    pub block_phrases: Vec<String>,
+    // pub block_phrases: Vec<String>,
+    pub block_phrases: HashMap<Uuid, String>
 }
 
 pub fn gen_config() {
+    let mut phr = HashMap::new();
+    phr.insert(Uuid::new_v4(), general_purpose::STANDARD_NO_PAD.encode("regy test phrase"));
     let config = Config {
         token: "token".to_string(),
         staff: vec!["000000000000000000".to_string()],
         log_channel: 000000000000000000,
-        block_phrases: vec![general_purpose::STANDARD_NO_PAD.encode("regy test phrase")],
+        // block_phrases: vec![general_purpose::STANDARD_NO_PAD.encode("regy test phrase")],
+        block_phrases: phr
     };
     //write to file
     let toml = toml::to_string(&config).unwrap();
@@ -29,18 +36,20 @@ pub fn get_config() -> Config {
 
 pub fn add_block_phrase (phrase: String) {
     let mut config = get_config();
-    config.block_phrases.push(general_purpose::STANDARD_NO_PAD.encode(phrase));
+    config.block_phrases.insert(Uuid::new_v4(),general_purpose::STANDARD_NO_PAD.encode(phrase));
     let toml = toml::to_string(&config).unwrap();
     std::fs::write("config.toml", toml).unwrap();
 }
 
-pub fn list_block_phrases () -> Vec<String> {
+pub fn list_block_phrases () -> HashMap<Uuid, String> {
     let config = get_config();
-    let mut phrases: Vec<String> = Vec::new();
-    for phrase in config.block_phrases {
+    // let mut phrases: Vec<String> = Vec::new();
+    let mut phrases: HashMap<Uuid, String> = HashMap::new();
+
+    for (id, phrase) in config.block_phrases {
         let phrase = String::from_utf8(general_purpose::STANDARD_NO_PAD.decode(&phrase).unwrap()).unwrap();
         let phrase = &phrase[..phrase.len() - 1];
-        phrases.push(phrase.to_string());
+        phrases.insert(id, phrase.to_string());
     }
     phrases
 }

--- a/src/managers/toml.rs
+++ b/src/managers/toml.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, hash::Hash};
+use std::{collections::HashMap};
 
 use uuid::Uuid;
 use base64::{Engine as _, engine::general_purpose};
@@ -40,6 +40,14 @@ pub fn add_block_phrase (phrase: String) {
     let toml = toml::to_string(&config).unwrap();
     std::fs::write("config.toml", toml).unwrap();
 }
+
+pub fn remove_block_phrase (id: Uuid) {
+    let mut config = get_config();
+    config.block_phrases.remove(&id);
+    let toml = toml::to_string(&config).unwrap();
+    std::fs::write("config.toml", toml).unwrap();
+}
+
 
 pub fn list_block_phrases () -> HashMap<Uuid, String> {
     let config = get_config();


### PR DESCRIPTION
Warning: config will be incompatible. Just rename the config file and let the program generate a new one, then copy over,

- Regex entries are now stored in a HashMap rather than a vector
- You can now remove regex's by finding their ID
- list_regex shows ID's of regex's 